### PR TITLE
Added metadata for mini-librispeech.

### DIFF
--- a/resources/31/about.html
+++ b/resources/31/about.html
@@ -1,0 +1,1 @@
+A subset of LibriSpeech created for the purpose of regression testing.

--- a/resources/31/info.txt
+++ b/resources/31/info.txt
@@ -1,0 +1,7 @@
+name: Mini LibriSpeech ASR corpus
+summary: Subset of LibriSpeech corpus for purpose of regression testing
+category: speech
+license: CC BY 4.0
+file: dev-clean-2.tar.gz development set, "clean" speech
+file: train-clean-5.tar.gz test set, "clean" speech
+file: md5sum.txt md5 checksums of files

--- a/resources/31/md5sum.txt
+++ b/resources/31/md5sum.txt
@@ -1,0 +1,2 @@
+6d7ab67ac6a1d2c993d050e16d61080d  dev-clean-2.tar.gz
+2b422a37d134a39506217720992d9d67  train-clean-5.tar.gz


### PR DESCRIPTION
I haven't checked how the web page looks, though.

@danpovey You can copy the .tar.gz files from /`home/ws15dgalvez/dgalvez/openslr/resources/31/*.tar.gz` on the CLSP servers. PR in the kaldi repo is on the way.