### PR TITLE
Fix filename for SLR42 High quality TTS data for Khmer

### DIFF
--- a/resources/42/info.txt
+++ b/resources/42/info.txt
@@ -2,5 +2,5 @@ name: High quality TTS data for Khmer.
 summary: Multi-speaker TTS data for Khmer (km-KH)
 category: speech
 license: Attribution-ShareAlike 4.0 (CC BY-SA 4.0)
-file: km_kh.male.zip Khmer data from male speakers
+file: km_kh_male.zip Khmer data from male speakers
 file: LICENSE License information


### PR DESCRIPTION
Fixes a typo in the filename (it now corresponds to the file name in the symbolic link). 