### PR TITLE
Bibliography data specific to most of the Google datasets.

### DIFF
--- a/resources/32/about.html
+++ b/resources/32/about.html
@@ -2,10 +2,22 @@ This data set contains multi-speaker high quality transcribed audio data for fou
 <p>
 The data set has had some quality checks, but there might still be errors.
 <p>
-This data set was collected by as a collaboration between North West University and Google
+This data set was collected by as a collaboration between North West University and Google.
 <p>
 See LICENSE.txt file for license information.
 <p>
 Copyright 2017 Google, Inc.
-
-
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{van-niekerk-etal-2017,
+    title = {{Rapid development of TTS corpora for four South African languages}},
+    author = {Daniel van Niekerk and Charl van Heerden and Marelie Davel and Neil Kleynhans and Oddur Kjartansson and Martin Jansche and Linne Ha},
+    booktitle = {Proc. Interspeech 2017},
+    pages = {2178--2182},
+    address = {Stockholm, Sweden},
+    month = aug,
+    year  = {2017},
+    URL   = {http://dx.doi.org/10.21437/Interspeech.2017-1139}
+  }
+</pre>

--- a/resources/35/about.html
+++ b/resources/35/about.html
@@ -7,3 +7,17 @@ This dataset was collected by Google in collaboration with Reykjavik University 
 See LICENSE.txt file for license information.
 <p>
 Copyright 2016, 2017 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-sltu2018,
+    title = {{Crowd-Sourced Speech Corpora for Javanese, Sundanese,  Sinhala, Nepali, and Bangladeshi Bengali}},
+    author = {Oddur Kjartansson and Supheakmungkol Sarin and Knot Pipatsrisawat and Martin Jansche and Linne Ha},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {52--55},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-11},
+  }
+</pre>

--- a/resources/36/about.html
+++ b/resources/36/about.html
@@ -7,3 +7,17 @@ This dataset was collected by Google in Indonesia.
 See LICENSE.txt file for license information.
 <p>
 Copyright 2016, 2017 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-sltu2018,
+    title = {{Crowd-Sourced Speech Corpora for Javanese, Sundanese,  Sinhala, Nepali, and Bangladeshi Bengali}},
+    author = {Oddur Kjartansson and Supheakmungkol Sarin and Knot Pipatsrisawat and Martin Jansche and Linne Ha},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {52--55},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-11},
+  }
+</pre>

--- a/resources/37/about.html
+++ b/resources/37/about.html
@@ -2,3 +2,16 @@ This data is transcribed high-quality speech data for Bengali.
 <p>
 The data collection was perfomed by Google.
 <p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-tts-sltu2018,
+    title = {{A Step-by-Step Process for Building TTS Voices Using Open Source Data and Framework for Bangla, Javanese, Khmer, Nepali, Sinhala, and Sundanese}},
+    author = {Keshan Sodimana and Knot Pipatsrisawat and Linne Ha and Martin Jansche and Oddur Kjartansson and Pasindu De Silva and Supheakmungkol Sarin},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {66--70},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-14}
+  }
+</pre>

--- a/resources/41/about.html
+++ b/resources/41/about.html
@@ -7,3 +7,17 @@ This dataset was collected by Google in collaboration with Gadjah Mada Universit
 See LICENSE file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google LLC
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-tts-sltu2018,
+    title = {{A Step-by-Step Process for Building TTS Voices Using Open Source Data and Framework for Bangla, Javanese, Khmer, Nepali, Sinhala, and Sundanese}},
+    author = {Keshan Sodimana and Knot Pipatsrisawat and Linne Ha and Martin Jansche and Oddur Kjartansson and Pasindu De Silva and Supheakmungkol Sarin},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {66--70},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-14}
+  }
+</pre>

--- a/resources/42/about.html
+++ b/resources/42/about.html
@@ -7,3 +7,17 @@ This dataset was collected by Google.
 See LICENSE file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google LLC
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-tts-sltu2018,
+    title = {{A Step-by-Step Process for Building TTS Voices Using Open Source Data and Framework for Bangla, Javanese, Khmer, Nepali, Sinhala, and Sundanese}},
+    author = {Keshan Sodimana and Knot Pipatsrisawat and Linne Ha and Martin Jansche and Oddur Kjartansson and Pasindu De Silva and Supheakmungkol Sarin},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {66--70},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-14}
+  }
+</pre>

--- a/resources/43/about.html
+++ b/resources/43/about.html
@@ -7,3 +7,17 @@ This dataset was collected by Google in Nepal.
 See LICENSE.txt file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google LLC
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-tts-sltu2018,
+    title = {{A Step-by-Step Process for Building TTS Voices Using Open Source Data and Framework for Bangla, Javanese, Khmer, Nepali, Sinhala, and Sundanese}},
+    author = {Keshan Sodimana and Knot Pipatsrisawat and Linne Ha and Martin Jansche and Oddur Kjartansson and Pasindu De Silva and Supheakmungkol Sarin},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {66--70},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-14}
+  }
+</pre>

--- a/resources/44/about.html
+++ b/resources/44/about.html
@@ -7,3 +7,17 @@ This dataset was collected by Google in collaboration with Universitas Pendidika
 See LICENSE file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google LLC
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-tts-sltu2018,
+    title = {{A Step-by-Step Process for Building TTS Voices Using Open Source Data and Framework for Bangla, Javanese, Khmer, Nepali, Sinhala, and Sundanese}},
+    author = {Keshan Sodimana and Knot Pipatsrisawat and Linne Ha and Martin Jansche and Oddur Kjartansson and Pasindu De Silva and Supheakmungkol Sarin},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {66--70},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-14}
+  }
+</pre>

--- a/resources/52/about.html
+++ b/resources/52/about.html
@@ -7,3 +7,17 @@ The data set has been manually quality checked, but there might still be errors.
 See LICENSE.txt file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-sltu2018,
+    title = {{Crowd-Sourced Speech Corpora for Javanese, Sundanese,  Sinhala, Nepali, and Bangladeshi Bengali}},
+    author = {Oddur Kjartansson and Supheakmungkol Sarin and Knot Pipatsrisawat and Martin Jansche and Linne Ha},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {52--55},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-11}
+  }
+</pre>

--- a/resources/53/about.html
+++ b/resources/53/about.html
@@ -7,3 +7,17 @@ The data set has been manually quality checked, but there might still be errors.
 See LICENSE.txt file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-sltu2018,
+    title = {{Crowd-Sourced Speech Corpora for Javanese, Sundanese,  Sinhala, Nepali, and Bangladeshi Bengali}},
+    author = {Oddur Kjartansson and Supheakmungkol Sarin and Knot Pipatsrisawat and Martin Jansche and Linne Ha},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {52--55},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-11}
+  }
+</pre>

--- a/resources/54/about.html
+++ b/resources/54/about.html
@@ -6,3 +6,17 @@ The data set has been manually quality checked, but there might still be errors.
 See LICENSE.txt file for license information.
 <p>
 Copyright 2016, 2017, 2018 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-sltu2018,
+    title = {{Crowd-Sourced Speech Corpora for Javanese, Sundanese,  Sinhala, Nepali, and Bangladeshi Bengali}},
+    author = {Oddur Kjartansson and Supheakmungkol Sarin and Knot Pipatsrisawat and Martin Jansche and Linne Ha},
+    booktitle = {Proc. The 6th Intl. Workshop on Spoken Language Technologies for Under-Resourced Languages (SLTU)},
+    year  = {2018},
+    address = {Gurugram, India},
+    month = aug,
+    pages = {52--55},
+    URL   = {http://dx.doi.org/10.21437/SLTU.2018-11}
+  }
+</pre>

--- a/resources/61/about.html
+++ b/resources/61/about.html
@@ -16,3 +16,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{guevara-rukoz-etal-2020-crowdsourcing,
+    title = {{Crowdsourcing Latin American Spanish for Low-Resource Text-to-Speech}},
+    author = {Guevara-Rukoz, Adriana and Demirsahin, Isin and He, Fei and Chu, Shan-Hui Cathy and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Gutkin, Alexander and Butryna, Alena and Kjartansson, Oddur},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    year = {2020},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.801},
+    pages = {6504--6513},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/63/about.html
+++ b/resources/63/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{he-etal-2020-open,
+    title = {{Open-source Multi-speaker Speech Corpora for Building Gujarati, Kannada, Malayalam, Marathi, Tamil and Telugu Speech Synthesis Systems}},
+    author = {He, Fei and Chu, Shan-Hui Cathy and Kjartansson, Oddur and Rivera, Clara and Katanova, Anna and Gutkin, Alexander and Demirsahin, Isin and Johny, Cibu and Jansche, Martin and Sarin, Supheakmungkol and Pipatsrisawat, Knot},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    pages = {6494--6503},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.800},
+    ISBN = "{979-10-95546-34-4},
+  }
+</pre>

--- a/resources/64/about.html
+++ b/resources/64/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{he-etal-2020-open,
+    title = {{Open-source Multi-speaker Speech Corpora for Building Gujarati, Kannada, Malayalam, Marathi, Tamil and Telugu Speech Synthesis Systems}},
+    author = {He, Fei and Chu, Shan-Hui Cathy and Kjartansson, Oddur and Rivera, Clara and Katanova, Anna and Gutkin, Alexander and Demirsahin, Isin and Johny, Cibu and Jansche, Martin and Sarin, Supheakmungkol and Pipatsrisawat, Knot},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    pages = {6494--6503},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.800},
+    ISBN = "{979-10-95546-34-4},
+  }
+</pre>

--- a/resources/65/about.html
+++ b/resources/65/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{he-etal-2020-open,
+    title = {{Open-source Multi-speaker Speech Corpora for Building Gujarati, Kannada, Malayalam, Marathi, Tamil and Telugu Speech Synthesis Systems}},
+    author = {He, Fei and Chu, Shan-Hui Cathy and Kjartansson, Oddur and Rivera, Clara and Katanova, Anna and Gutkin, Alexander and Demirsahin, Isin and Johny, Cibu and Jansche, Martin and Sarin, Supheakmungkol and Pipatsrisawat, Knot},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    pages = {6494--6503},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.800},
+    ISBN = "{979-10-95546-34-4},
+  }
+</pre>

--- a/resources/66/about.html
+++ b/resources/66/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{he-etal-2020-open,
+    title = {{Open-source Multi-speaker Speech Corpora for Building Gujarati, Kannada, Malayalam, Marathi, Tamil and Telugu Speech Synthesis Systems}},
+    author = {He, Fei and Chu, Shan-Hui Cathy and Kjartansson, Oddur and Rivera, Clara and Katanova, Anna and Gutkin, Alexander and Demirsahin, Isin and Johny, Cibu and Jansche, Martin and Sarin, Supheakmungkol and Pipatsrisawat, Knot},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    pages = {6494--6503},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.800},
+    ISBN = "{979-10-95546-34-4},
+  }
+</pre>

--- a/resources/69/about.html
+++ b/resources/69/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-2020-open,
+    title = {{Open-Source High Quality Speech Datasets for Basque, Catalan and Galician}},
+    author = {Kjartansson, Oddur and Gutkin, Alexander and Butryna, Alena and Demirsahin, Isin and Rivera, Clara},
+    booktitle = {Proceedings of the 1st Joint Workshop on Spoken Language Technologies for Under-resourced languages (SLTU) and Collaboration and Computing for Under-Resourced Languages (CCURL)},
+    year = {2020},
+    pages = {21--27},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.sltu-1.3},
+    ISBN = {979-10-95546-35-1},
+  }
+</pre>

--- a/resources/71/about.html
+++ b/resources/71/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{guevara-rukoz-etal-2020-crowdsourcing,
+    title = {{Crowdsourcing Latin American Spanish for Low-Resource Text-to-Speech}},
+    author = {Guevara-Rukoz, Adriana and Demirsahin, Isin and He, Fei and Chu, Shan-Hui Cathy and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Gutkin, Alexander and Butryna, Alena and Kjartansson, Oddur},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    year = {2020},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.801},
+    pages = {6504--6513},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/72/about.html
+++ b/resources/72/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{guevara-rukoz-etal-2020-crowdsourcing,
+    title = {{Crowdsourcing Latin American Spanish for Low-Resource Text-to-Speech}},
+    author = {Guevara-Rukoz, Adriana and Demirsahin, Isin and He, Fei and Chu, Shan-Hui Cathy and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Gutkin, Alexander and Butryna, Alena and Kjartansson, Oddur},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    year = {2020},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.801},
+    pages = {6504--6513},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/73/about.html
+++ b/resources/73/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{guevara-rukoz-etal-2020-crowdsourcing,
+    title = {{Crowdsourcing Latin American Spanish for Low-Resource Text-to-Speech}},
+    author = {Guevara-Rukoz, Adriana and Demirsahin, Isin and He, Fei and Chu, Shan-Hui Cathy and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Gutkin, Alexander and Butryna, Alena and Kjartansson, Oddur},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    year = {2020},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.801},
+    pages = {6504--6513},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/74/about.html
+++ b/resources/74/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{guevara-rukoz-etal-2020-crowdsourcing,
+    title = {{Crowdsourcing Latin American Spanish for Low-Resource Text-to-Speech}},
+    author = {Guevara-Rukoz, Adriana and Demirsahin, Isin and He, Fei and Chu, Shan-Hui Cathy and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Gutkin, Alexander and Butryna, Alena and Kjartansson, Oddur},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    year = {2020},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.801},
+    pages = {6504--6513},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/75/about.html
+++ b/resources/75/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{guevara-rukoz-etal-2020-crowdsourcing,
+    title = {{Crowdsourcing Latin American Spanish for Low-Resource Text-to-Speech}},
+    author = {Guevara-Rukoz, Adriana and Demirsahin, Isin and He, Fei and Chu, Shan-Hui Cathy and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Gutkin, Alexander and Butryna, Alena and Kjartansson, Oddur},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    year = {2020},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.801},
+    pages = {6504--6513},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/76/about.html
+++ b/resources/76/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-2020-open,
+    title = {{Open-Source High Quality Speech Datasets for Basque, Catalan and Galician}},
+    author = {Kjartansson, Oddur and Gutkin, Alexander and Butryna, Alena and Demirsahin, Isin and Rivera, Clara},
+    booktitle = {Proceedings of the 1st Joint Workshop on Spoken Language Technologies for Under-resourced languages (SLTU) and Collaboration and Computing for Under-Resourced Languages (CCURL)},
+    year = {2020},
+    pages = {21--27},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.sltu-1.3},
+    ISBN = {979-10-95546-35-1},
+  }
+</pre>

--- a/resources/77/about.html
+++ b/resources/77/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{kjartansson-etal-2020-open,
+    title = {{Open-Source High Quality Speech Datasets for Basque, Catalan and Galician}},
+    author = {Kjartansson, Oddur and Gutkin, Alexander and Butryna, Alena and Demirsahin, Isin and Rivera, Clara},
+    booktitle = {Proceedings of the 1st Joint Workshop on Spoken Language Technologies for Under-resourced languages (SLTU) and Collaboration and Computing for Under-Resourced Languages (CCURL)},
+    year = {2020},
+    pages = {21--27},
+    month = may,
+    address = {Marseille, France},
+    publisher = {European Language Resources association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.sltu-1.3},
+    ISBN = {979-10-95546-35-1},
+  }
+</pre>

--- a/resources/78/about.html
+++ b/resources/78/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{he-etal-2020-open,
+    title = {{Open-source Multi-speaker Speech Corpora for Building Gujarati, Kannada, Malayalam, Marathi, Tamil and Telugu Speech Synthesis Systems}},
+    author = {He, Fei and Chu, Shan-Hui Cathy and Kjartansson, Oddur and Rivera, Clara and Katanova, Anna and Gutkin, Alexander and Demirsahin, Isin and Johny, Cibu and Jansche, Martin and Sarin, Supheakmungkol and Pipatsrisawat, Knot},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    pages = {6494--6503},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.800},
+    ISBN = "{979-10-95546-34-4},
+  }
+</pre>

--- a/resources/79/about.html
+++ b/resources/79/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{he-etal-2020-open,
+    title = {{Open-source Multi-speaker Speech Corpora for Building Gujarati, Kannada, Malayalam, Marathi, Tamil and Telugu Speech Synthesis Systems}},
+    author = {He, Fei and Chu, Shan-Hui Cathy and Kjartansson, Oddur and Rivera, Clara and Katanova, Anna and Gutkin, Alexander and Demirsahin, Isin and Johny, Cibu and Jansche, Martin and Sarin, Supheakmungkol and Pipatsrisawat, Knot},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    pages = {6494--6503},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.800},
+    ISBN = "{979-10-95546-34-4},
+  }
+</pre>

--- a/resources/80/about.html
+++ b/resources/80/about.html
@@ -13,3 +13,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{oo-etal-2020-burmese,
+    title = {{Burmese Speech Corpus, Finite-State Text Normalization and Pronunciation Grammars with an Application to Text-to-Speech}},
+    author = {Oo, Yin May and Wattanavekin, Theeraphol and Li, Chenfang and De Silva, Pasindu and Sarin, Supheakmungkol and Pipatsrisawat, Knot and Jansche, Martin and Kjartansson, Oddur and Gutkin, Alexander},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    pages = "6328--6339",
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.777},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>

--- a/resources/83/about.html
+++ b/resources/83/about.html
@@ -31,3 +31,19 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{demirsahin-etal-2020-open,
+    title = {{Open-source Multi-speaker Corpora of the English Accents in the British Isles}},
+    author = {Demirsahin, Isin and Kjartansson, Oddur and Gutkin, Alexander and Rivera, Clara},
+    booktitle = {Proceedings of The 12th Language Resources and Evaluation Conference (LREC)},
+    month = may,
+    year = {2020},
+    pages = {6532--6541},
+    address = {Marseille, France},
+    publisher = {European Language Resources Association (ELRA)},
+    url = {https://www.aclweb.org/anthology/2020.lrec-1.804},
+    ISBN = {979-10-95546-34-4},
+  }
+</pre>


### PR DESCRIPTION
This should be resolving PR #3: The bibitems are added verbatim to the corresponding `about.html` index pages.