### PR TITLE
[SLR86] Adding reference publication for the Yoruba corpus. 

### DIFF
--- a/resources/86/about.html
+++ b/resources/86/about.html
@@ -14,3 +14,17 @@ Please report any issues in the following issue tracker on GitHub.
 See LICENSE file for license information.
 <p>
 Copyright 2018, 2019, 2020 Google, Inc.
+<p>
+If you use this data in publications, please cite it as follows:
+<pre>
+  @inproceedings{gutkin-et-al-yoruba2020,
+    title = {{Developing an Open-Source Corpus of Yoruba Speech}},
+    author = {Alexander Gutkin and I{\c{s}}{\i}n Demir{\c{s}}ahin and Oddur Kjartansson and Clara Rivera and K\d{\'o}lá Túb\d{\`o}sún},
+    booktitle = {Proceedings of Interspeech 2020},
+    month = {October},
+    year = {2020},
+    address = {Shanghai, China},
+    publisher = {International Speech and Communication Association (ISCA)},
+    note = {To appear}
+  }
+</pre>


### PR DESCRIPTION
Per issue #7 adding a citation documenting the development of Yoruba corpus.

Will add the page numbers later when the paper is physically published.